### PR TITLE
feat: Update types & add support computed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,12 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
 import { reactive, watch, toValue, type MaybeRefOrGetter } from 'vue'
 
+type Combine<T, K extends PropertyKey = T extends unknown ? keyof T : never> = T extends unknown
+  ? T & Partial<Record<Exclude<K, keyof T>, never>>
+  : never
+
 type Issues<T> = {
-  [Key in keyof T]?: T[Key] extends object ? Issues<T[Key]> : string[]
+  [Key in keyof Combine<T>]?: Combine<T>[Key] extends object ? Issues<Combine<T>[Key]> : string[]
 }
 
 export function useValidation<T extends Record<string, unknown>>(data: MaybeRefOrGetter<T>, schema: StandardSchemaV1<T>) {


### PR DESCRIPTION
First point is correct types for issues.

I just added `Combine` type which concat all options from schema.

For example if I use union schema
```ts
const baseSchema = z.object({ email: z.email(), mode: z.enum(["email", "login", "signup"]).default("email").optional() });
const emailSchema = baseSchema.extend({ mode: z.literal("email").optional() });
const signinSchema = baseSchema.extend({ mode: z.literal("login"), password: z.string().min(1, "Password is required") });
const signupSchema = baseSchema.extend({ mode: z.literal("signup"), code: z.string().length(6, "Code is required") });

const authSchema = z.discriminatedUnion("mode", [emailSchema, signinSchema, signupSchema]);

const form = reactive<AuthPayload>({ email: "", mode: "email" });
const { validate, issues } = useValidation(form, authSchema);
```
```vue
<div v-if="form.mode === 'login'" class="grid gap-2">
					<div class="flex items-center">
						<Label for="password">Password</Label>
						<a href="#" class="ml-auto text-sm text-muted-foreground underline-offset-4 hover:underline"> Forgot your password? </a>
					</div>
					<Input
						id="password"
						v-model="form.password"
						:aria-invalid="issues.password"
						name="password"
						type="password"
						placeholder="******"
					/>
...
```
I got TS error in `issues.password`:

> The "password" property does not exist in the "Reactive<Issues<{ email: string; mode?: "email" | undefined; } | { email: string; mode: "login"; password: string; } | { email: string; mode: "signup"; code: string; }>>".
>   The "password" property does not exist in the type "{email?: string[] | undefined; mode?: string[] | undefined; }".ts-plugin(2339)

Because issues has same type as form:
```ts
const issues: Reactive<Issues<{
    email: string;
    mode?: "email" | undefined;
} | {
    email: string;
    mode: "login";
    password: string;
} | {
    email: string;
    mode: "signup";
    code: string;
}>>
```

And with Combine type integration we're got issues type like this:
```ts
const issues: {
    email?: string[] | undefined;
    mode?: string[] | undefined;
    code?: string[] | undefined;
    password?: string[] | undefined;
}
```

---

Another one point - using `MaybeRefOrGetter` instead `MaybeRef`. This is full backward compatible update but may be useful for specific cases with computed and getters data as form 